### PR TITLE
Upgrading symfony/console dependency to latest stable (4.0)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.6",
-        "symfony/console": "~2.8|~3.0"
+        "symfony/console": "~2.8|~3.0|~4.0"
     },
     "require-dev": {
         "composer/composer": "1.0.*@dev",


### PR DESCRIPTION
Hi, I tried to follow in your footsteps of using particular versions of the console dependency, this fix worked for me in a repo I'm working on. Thanks!