### PR TITLE
Fix: command option keep-outdated

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ Compare `.env-target` with `.env.example` and add missing variables to `.env-tar
 php ./vendor/bin/env-diff actualize .env.example .env-target
 ```
 
-If you want to delete outdated values just run command with `-k=false` option.
+If you want to remove outdated values just run command with `-r` option.
 
 ```
-php ./vendor/bin/env-diff actualize -k=false
+php ./vendor/bin/env-diff actualize -r
 ```
 
 ### Show differences

--- a/src/Console/Command/AbstractCommand.php
+++ b/src/Console/Command/AbstractCommand.php
@@ -21,7 +21,7 @@ abstract class AbstractCommand extends Command
         $this
             ->addArgument('dist', InputOption::VALUE_REQUIRED, 'From file', Config::DEFAULT_DIST)
             ->addArgument('target', InputOption::VALUE_REQUIRED, 'To file', Config::DEFAULT_TARGET)
-            ->addOption('keep-outdated', 'k', InputOption::VALUE_OPTIONAL, 'Keep old env variables', true);
+            ->addOption('remove-outdated', 'r', InputOption::VALUE_NONE, 'Remove old env variables');
     }
 
     /**
@@ -48,11 +48,11 @@ abstract class AbstractCommand extends Command
      */
     private function createConfig(InputInterface $input)
     {
-        $dist         = $input->getArgument('dist');
-        $target       = $input->getArgument('target');
-        $keepOutdated = $input->getOption('keep-outdated');
+        $dist           = $input->getArgument('dist');
+        $target         = $input->getArgument('target');
+        $removeOutdated = $input->getOption('remove-outdated');
 
-        return new Config($dist, $target, $keepOutdated);
+        return new Config($dist, $target, !$removeOutdated);
     }
 
     /**


### PR DESCRIPTION
## Why
The option `keep-outdated` doesn't work as it is a string compared to a boolean. Whatever its value, it's not going to be strictly equal to `false` (from the command line).

## How
We want to keep old value by default. And by putting the option, we expect to remove them.
Since a boolean value is expected, change the option to be a boolean option (without value), with a name matching the opposite of its default behavior.
