### PR TITLE
Remove ksort on var name on actualize

### DIFF
--- a/src/Processor.php
+++ b/src/Processor.php
@@ -52,7 +52,6 @@ class Processor
             mkdir($dir, 0755, true);
         }
 
-        ksort($actualEnv);
         file_put_contents($target, Env::dump($actualEnv));
 
         $this->io->write(sprintf('<info>"%s" has been %s</info>', $target, $exists ? 'updated' : 'created'));


### PR DESCRIPTION
The `ksort` would break the .env file in the following case:
```
FOO=anything
BAR=${FOO}
```
The actualize method would have break the dependencies between env vars and generate something like:
```
BAR=${FOO} # FOO is undefined here
FOO=anything
```


